### PR TITLE
Fix bug in List(Data) not deserializing the correct data

### DIFF
--- a/capnp.lua
+++ b/capnp.lua
@@ -584,7 +584,7 @@ function _M.read_list_data(p32, header, num, elm_type, ...)
             local off, child_size, child_num = _M.read_listp_list(p32,
                     header, i)
             if off and child_num then
-                t[i] = _M.read_text_data(p32 + (1 + off) * 2, child_num)
+                t[i] = _M.read_text_data(p32 + (i + off) * 2, child_num)
             end
         end
     elseif elm_type == "struct" then

--- a/proto/example.capnp
+++ b/proto/example.capnp
@@ -64,6 +64,7 @@ struct T1 {
     end @23 :Bool; # "end" is lua's reserved word
     o0  @24 :AnyPointer;
     lt0 @25 :List(Text);
+    ld0 @27 :List(Data);
 #    u1: union {
 #        g1 :group {
 #            v1 @17 :Void;
@@ -76,7 +77,7 @@ struct T1 {
     const welcomeText :Text = "Hello";
 # Doesn't work for now
 #    const constT2 :T2 = (f0 = 12345.67, f1 = 9876.54, sd0 = "\0\1\2\3");
-    u64 @27 :UInt64;
+    u64 @28 :UInt64;
 }
 
 struct T3 {

--- a/tests/10-encode-decode.lua
+++ b/tests/10-encode-decode.lua
@@ -26,7 +26,7 @@ function test_basic_value()
         i0 = 32,
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(data.i0, copy.i0)
@@ -47,7 +47,7 @@ function test_basic_value1()
         b0 = true,
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -68,7 +68,7 @@ function test_basic_value2()
         i2 = -8,
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -89,7 +89,7 @@ function test_basic_value3()
         s0 = {},
     }
 
-    assert_equal(152, hw_capnp.T1.calc_size(data))
+    assert_equal(136 + 24, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -138,7 +138,7 @@ function test_basic_value4()
         l0 = { 1, -1, 127 }
     }
 
-    assert_equal(136, hw_capnp.T1.calc_size(data))
+    assert_equal(136 + 8, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -162,7 +162,7 @@ function test_basic_value5()
         t0 = "1234567890~!#$%^&*()-=_+[]{};':|,.<>/?"
     }
 
-    assert_equal(128 + 40, hw_capnp.T1.calc_size(data))
+    assert_equal(136 + 40, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -198,7 +198,7 @@ function test_basic_value6()
     }
 
     -- header + T1.size + T2.size + l0 + t0
-    assert_equal(16 + 112 + 24 + 8 + 8, hw_capnp.T1.calc_size(data))
+    assert_equal(16 + 120 + 24 + 8 + 8, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     util.write_file("dump", bin)
     copy  = hw_capnp.T1.parse(bin, copy)
@@ -225,7 +225,7 @@ function test_union_value()
         ui1 = 32,
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -249,7 +249,7 @@ function test_union_value()
         uv0 = "Void",
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -275,7 +275,7 @@ function test_union_value()
         },
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -302,7 +302,7 @@ function test_union_group()
         },
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -333,7 +333,7 @@ function test_union_group1()
         },
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -366,7 +366,7 @@ function test_union_group2()
         },
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -405,7 +405,7 @@ function test_struct_list()
         },
     }
 
-    assert_equal(128 + 8 + 24 * 2, hw_capnp.T1.calc_size(data))
+    assert_equal(136 + 8 + 24 * 2, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -437,7 +437,7 @@ function test_default_value()
     local data = {
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -467,7 +467,7 @@ function test_default_value1()
         du0 = 630,
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -496,7 +496,7 @@ function test_default_value2()
         db0 = true
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -526,7 +526,7 @@ function test_reserved_word()
         ["end"] = true
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -560,7 +560,7 @@ function test_list_of_text()
         }
     }
 
-    assert_equal(128 + 4 * 8 + 8 + 8 + 16 + 16, hw_capnp.T1.calc_size(data))
+    assert_equal(136 + 4 * 8 + 8 + 8 + 16 + 16, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -597,6 +597,29 @@ function test_list_of_text()
     assert_equal(data.lt0[4], copy.lt0[4])
 end
 
+function test_list_of_data()
+    local data = {
+        ld0 = {
+            "B\x0A\x0Ch", "M\x00z\x0Art", "B\xEEthoven", "Tch\x0Aik\x00vsky",
+        }
+    }
+
+    assert_equal(128 + 4 * 8 + 8 + 8 + 16 + 16, hw_capnp.T1.calc_size(data))
+    local bin   = hw_capnp.T1.serialize(data)
+    copy  = hw_capnp.T1.parse(bin, copy)
+    assert_not_nil(copy.ld0)
+    assert_equal(4, #copy.ld0)
+    assert_not_nil(copy.ld0[1])
+    assert_not_nil(copy.ld0[2])
+    assert_not_nil(copy.ld0[3])
+    assert_not_nil(copy.ld0[4])
+    assert_equal(data.ld0[1], copy.ld0[1])
+    assert_equal(data.ld0[2], copy.ld0[2])
+    assert_equal(data.ld0[3], copy.ld0[3])
+    assert_equal(data.ld0[4], copy.ld0[4])
+end
+
+
 function test_const()
     assert_equal(3.14159, hw_capnp.pi)
     assert_equal("Hello", hw_capnp.T1.welcomeText)
@@ -629,7 +652,7 @@ function test_uint64()
         u64 = uint64p[0],
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -654,7 +677,7 @@ function test_lower_space_naming()
         e1 = "lower space"
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal("lower space", copy.e1)
@@ -666,7 +689,7 @@ function test_type_check_when_calc_size()
         s0 = "I should be a lua table, not a string",
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal(0, copy.i0)
@@ -687,7 +710,7 @@ function test_get_enum_from_number()
         e1 = 7, -- "lower space"
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal("lower space", copy.e1)
@@ -698,7 +721,7 @@ function test_unknown_enum_value()
         e1 = "I AM AN UNKNOWN ENUM",
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal("none", copy.e1)
@@ -709,7 +732,7 @@ function test_empty_enum_value()
         e1 = "",
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     copy  = hw_capnp.T1.parse(bin, copy)
     assert_equal("none", copy.e1)
@@ -746,7 +769,7 @@ function test_serialize_cdata()
         i0 = 32,
     }
 
-    assert_equal(128, hw_capnp.T1.calc_size(data))
+    assert_equal(136, hw_capnp.T1.calc_size(data))
     local bin   = hw_capnp.T1.serialize(data)
     local arr, len = hw_capnp.T1.serialize_cdata(data)
     assert_equal(#bin, len)


### PR DESCRIPTION
master right now has a typo where a loop iterator `i` is the number literal `1` in capnp.lua. As a result when deserializing a List(Data), the first element of the list is returned for *every* element of the list!