### PR TITLE
Fix error args on bad enum

### DIFF
--- a/capnp.lua
+++ b/capnp.lua
@@ -337,7 +337,7 @@ function _M.get_enum_name(v, default, enum_schema, name)
     v = bxor(v, default) -- starts from 0
     local r = enum_schema[v]
     if not r then
-        error(name, " Unknown enum val:", v, ", out of range")
+        error((name or "") .. " Unknown enum val:" .. v .. ", out of range")
     end
     return r
 end


### PR DESCRIPTION
The Lua error function takes two args: the error string and an integer level. This means the message needs to be concatenated rather than comma-separated. In this case on bad enums we get `bad argument #2 to 'error' (number expected, got string)` when we should really get the message.

Just use concatenation on the string and handle when `name` can be nil.